### PR TITLE
Ambiguous move clarification

### DIFF
--- a/2D Simulation/blocks.js
+++ b/2D Simulation/blocks.js
@@ -71,6 +71,18 @@ let blocks = new function () {
         currentConfig[id].topLetter = newLetter;
         currentConfig[id].bottomLetter = oldLetter;
     };
+
+    this.display_block_ids = function() {
+        for (let i = 0; i < NumBlocks; i++) {
+            blocks.set_block_text(i, i);
+        }
+    };
+
+    this.display_block_letters = function() {
+        for (let i = 0; i < NumBlocks; i++) {
+            blocks.set_block_text(i, currentConfig[i].topLetter);
+        }
+    };
 };
 
 if (typeof module !== 'undefined'

--- a/2D Simulation/game.js
+++ b/2D Simulation/game.js
@@ -162,9 +162,7 @@ socket.on('indicate_impossible_move', function(move) {
     alert(message);
 });
 
-socket.on('indicate_ambiguous_move', function(move) {
-    movesCorrector.handle_ambiguity(move);
-});
+socket.on('indicate_ambiguous_move', movesCorrector.handle_ambiguity);
 
 socket.on('setInitialPosition', function(data) {
     document.getElementById('user1').innerText = "Player 1";
@@ -265,6 +263,7 @@ socket.on('setInitialPosition', function(data) {
     };
     setIntroduction(2);
 });
+
 function send_flip_to_server(block_id) {
     try {
         socket.emit('receive_flip_block', block_id);
@@ -274,6 +273,7 @@ function send_flip_to_server(block_id) {
     }
 
 }
+
 $(document).ready(function() {
     $(".draggable").draggable();
 
@@ -318,9 +318,6 @@ function send_user_message_to_server(gameConfig) {
 
     if (start_button_pressed) {
         if (movesCorrector.handle_message(message)) {
-            return;
-        } else if (movesCorrector.is_handling_ambiguity()) {
-            movesCorrector.finish_handling_ambiguity(message);
             return;
         }
 

--- a/2D Simulation/game.js
+++ b/2D Simulation/game.js
@@ -107,9 +107,7 @@ socket.on('enable_blocks_for_player_2', function(data) {
     }
 });
 
-socket.on('update_position', function (moveData) {
-    update_position(moveData);
-});
+socket.on('update_position', update_position);
 
 function update_position(moveData) {
     movesCorrector.update_undo_move(moveData);
@@ -143,9 +141,7 @@ function update_gui_block(moveData) {
                           left, top);
 }
 
-socket.on('update_flip_block', function (block_id) {
-    update_flip_block(block_id);
-});
+socket.on('update_flip_block', update_flip_block);
 
 function update_flip_block(block_id) {
     let id = block_id.substring(5);
@@ -167,14 +163,6 @@ socket.on('indicate_impossible_move', function(move) {
 });
 
 socket.on('indicate_ambiguous_move', function(move) {
-    let color = move['predicted_color'] || 'Ambiguous';
-    let letter = move['predicted_letter'] || 'Ambiguous';
-    let message = 'I think that this is an ambiguous move. '
-        + 'Please try a more specific instruction.\n'
-        + 'Predicted color: ' + color + '\n'
-        + 'Predicted letter: ' + letter + '\n'
-        + 'Enter the identifier of the intended block.';
-    alert(message);
     movesCorrector.handle_ambiguity(move);
 });
 

--- a/2D Simulation/game.js
+++ b/2D Simulation/game.js
@@ -164,8 +164,6 @@ socket.on('indicate_impossible_move', function(move) {
         + 'Predicted letter: ' + letter;
 
     alert(message);
-
-    movesCorrector.handle_ambiguity();
 });
 
 socket.on('indicate_ambiguous_move', function(move) {

--- a/2D Simulation/movesCorrector.js
+++ b/2D Simulation/movesCorrector.js
@@ -37,6 +37,16 @@ let movesCorrector = new function () {
         undo_action = undefined;
     }
 
+    function display_ambiguous_move_explanation(move) {
+        let color = move['predicted_color'] || 'Ambiguous';
+        let letter = move['predicted_letter'] || 'Ambiguous';
+        let message = 'I think that this is an ambiguous move. '
+            + 'Predicted color: ' + color + '\n'
+            + 'Predicted letter: ' + letter + '\n'
+            + 'Enter the identifier of the intended block.';
+        alert(message);
+    };
+
     function display_flip_explanation() {
         alert("Please enter the id number of the block you wanted to flip.");
     }
@@ -101,26 +111,31 @@ let movesCorrector = new function () {
     };
 
     this.handle_ambiguity = function(currMove) {
-        console.log('handling ambiguity');
         handling_ambiguity = true;
         move = currMove;
+        display_ambiguous_move_explanation(move);
         blocks.display_block_ids();
     };
 
     this.finish_handling_ambiguity = function(message) {
-        console.log('this should be doing it.');
         let id = convert_message_to_id_num(message);
-        move.block_id = 'block' + id;
 
-        handling_ambiguity = false;
-        blocks.display_block_letters();
+        if (message !== "" && is_valid_id(id)) {
 
-        if (move.type == 'ambiguous_move') {
-            move.type = 'move';
-            update_position(move);
-        } else if (move.type == 'ambiguous_flip') {
-            move.type = 'flip';
-            update_flip_block(move.block_id);
+            move.block_id = 'block' + id;
+
+            handling_ambiguity = false;
+            blocks.display_block_letters();
+
+            if (move.type == 'ambiguous_move') {
+                move.type = 'move';
+                update_position(move);
+            } else if (move.type == 'ambiguous_flip') {
+                move.type = 'flip';
+                update_flip_block(move.block_id);
+            }
+        } else {
+            display_ambiguous_move_explanation(move);
         }
     };
 };

--- a/2D Simulation/movesCorrector.js
+++ b/2D Simulation/movesCorrector.js
@@ -83,32 +83,32 @@ let movesCorrector = new function () {
     };
 
     this.handle_message = function (message) {
-        if (!awaiting_correction)
-            return false;
+        if (awaiting_correction) {
+            let id = convert_message_to_id_num(message);
 
-        let id = convert_message_to_id_num(message);
+            if (message !== "" && is_valid_id(id)) {
+                flipBlock("block" + id,
+                          blocks.get_block_text(id),
+                          blocks.get_block_color(id),
+                          currentConfig);
+                awaiting_correction = false;
+                blocks.display_block_letters();
+            } else {
+                display_flip_explanation();
+            }
 
-        if (message !== "" && is_valid_id(id)) {
-            flipBlock("block" + id,
-                      blocks.get_block_text(id),
-                      blocks.get_block_color(id),
-                      currentConfig);
-            awaiting_correction = false;
-            blocks.display_block_letters();
-        } else {
-            display_flip_explanation();
+            return true;
+        } else if (handling_ambiguity) {
+            finish_handling_ambiguity(message);
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     function is_valid_id(id) {
         return id % 1 === 0 && id >= 0 && id < NumBlocks;
     }
-
-    this.is_handling_ambiguity = function() {
-        return handling_ambiguity;
-    };
 
     this.handle_ambiguity = function(currMove) {
         handling_ambiguity = true;
@@ -117,7 +117,7 @@ let movesCorrector = new function () {
         blocks.display_block_ids();
     };
 
-    this.finish_handling_ambiguity = function(message) {
+    function finish_handling_ambiguity(message) {
         let id = convert_message_to_id_num(message);
 
         if (message !== "" && is_valid_id(id)) {

--- a/server/emits.py
+++ b/server/emits.py
@@ -54,46 +54,23 @@ def setup_updates(sio, rooms_tracker):
         elif move['type'] == 'impossible':
             self_emit(sio, sid, 'indicate_impossible_move',
                       rooms_tracker, move)
-        elif move['type'] == 'ambiguous':
-            self_emit(sio, sid, 'indicate_ambiguous_move',
-                      rooms_tracker, move)
+        elif move['type'] == 'ambiguous_flip' or move['type'] == 'ambiguous_move':
+            self_emit(sio, sid, 'indicate_ambiguous_move', rooms_tracker, move)
         else:
-            move = model.generate_move(
-                sid,
-                gesture[sid],
-                data
-            )
-            gesture[sid] = None
+            # Transmit id as 'block<id>'
+            move_data = {
+                'top': move['top'],
+                'left': move['left'],
+                'block_id': move['block_id'][1:]
+            }
 
-            if not move:
-                print("Failed to find the requested block.")
-                return
-
-            # Messages to be cleaned up with issue #25
-            if move['type'] == 'flip':
-                # Transmit id as 'block<id>'
-                self_emit(sio, sid, 'update_flip_block',
-                          rooms_tracker, move['block_id'][1:])
-            elif move['type'] == 'impossible':
-                self_emit(sio, sid, 'indicate_impossible_move',
-                          rooms_tracker, move)
-            elif move['type'] == 'ambiguous_flip' or move['type'] == 'ambiguous_move':
-                self_emit(sio, sid, 'indicate_ambiguous_move', rooms_tracker, move)
-            else:
-                # Transmit id as 'block<id>'
-                move_data = {
-                    'top': move['top'],
-                    'left': move['left'],
-                    'block_id': move['block_id'][1:]
-                }
-
-                self_emit(sio, sid, 'update_position',
-                          rooms_tracker, move_data)
-                self_emit(sio, sid, 'update_movement_data',
-                          rooms_tracker, move['move_number'])
-                # Transmit id as 'block<id>'
-                self_emit(sio, sid, 'Update_score',
-                          rooms_tracker, move_data)
+            self_emit(sio, sid, 'update_position',
+                      rooms_tracker, move_data)
+            self_emit(sio, sid, 'update_movement_data',
+                      rooms_tracker, move['move_number'])
+            # Transmit id as 'block<id>'
+            self_emit(sio, sid, 'Update_score',
+                      rooms_tracker, move_data)
 
     sio.on('receive_gesture_data', gesture_handler)
     sio.on('receive_user_message', user_message_handler)

--- a/server/neural_network_interface.py
+++ b/server/neural_network_interface.py
@@ -55,7 +55,12 @@ class NeuralNetworkBlocksworldModel(BlocksworldModel):
         if len(candidates) == 0:
             return self._build_impossible(letter_tup[0], color_tup[0])
         if len(candidates) > 1:
-            return self._build_ambiguous(letter_tup[0], color_tup[0], candidates)
+            return self._build_ambiguous(flip_tup[0],
+                                         letter_tup[0],
+                                         color_tup[0],
+                                         candidates,
+                                         gesture_data,
+                                         sid)
 
         block_id = candidates[0]
         if flip_tup[0] == 'Flip':
@@ -82,12 +87,15 @@ class NeuralNetworkBlocksworldModel(BlocksworldModel):
             'move_number': self._movement_count_dict[sid]
         }
 
-    def _build_ambiguous(self, letter, color, block_candidates):
+    def _build_ambiguous(self, action, letter, color, block_candidates, gesture_data, sid):
         return {
-            'type': 'ambiguous',
+            'type': 'ambiguous_flip' if action == 'Flip' else 'ambiguous_move',
             'predicted_letter': letter if letter != 'None' else False,
             'predicted_color': color if color != 'None' else False,
-            'candidates': block_candidates
+            'candidates': block_candidates,
+            'top': gesture_data['top'],
+            'left': gesture_data['left'],
+            'move_number': self._movement_count_dict[sid]
         }
 
     def _build_impossible(self, letter, color):

--- a/server/neural_network_interface.py
+++ b/server/neural_network_interface.py
@@ -47,7 +47,6 @@ class NeuralNetworkBlocksworldModel(BlocksworldModel):
 
         (flip_tup, color_tup, letter_tup) = self._run_models(message)
 
-
         ambig_letter = letter_tup if letter_tup[1] > self.ambiguity_threshold else ('None', 1)
         ambig_color = color_tup if color_tup[1] > self.ambiguity_threshold else ('None', 1)
         candidates = _find_block(game_state, ambig_color[0], ambig_letter[0])


### PR DESCRIPTION
I am using some of the code from Lewis' PR, so this should not be merged before his PR.

Basic ambiguous move clarification. I think it probably should only allow you to specify one of the blocks that was a move candidate, I can add that in the very near future. 

Works nearly identically to Lewis' additions. When an ambiguous move is detected, prompts for a block ID. It then moves/flips that block. 